### PR TITLE
Remove extra background-contain

### DIFF
--- a/hosts/www.drive2.ru/style.css
+++ b/hosts/www.drive2.ru/style.css
@@ -32,7 +32,6 @@
 .header__title-link {
     width: 120px;
     height: 50px;
-    background-size: contain;
     background: #c03 url(./logo.svg) no-repeat;
 }
 


### PR DESCRIPTION
Картинке уже заданы размеры, поэтому свойство `background-contain` лишнее. Из-за его наличия в ios11 safari исчезает логотип.

### Примеры турбо-страниц
- https://yandex.ru/turbo?text=https://www.drive2.ru

### Изменения проверены в следующих браузерах
- [x] Android 4+
- [x] iOS 9+
- [x] IE 11
<span id="turbo-content-start"></span>

****

🚀 https://rozhdestvenskiy.ru/ — [master](https://master.turboext.net/turbo?text=https://rozhdestvenskiy.ru/), [pull request](https://pull-23.turboext.net/turbo?text=https://rozhdestvenskiy.ru/)