### PR TITLE
Stylelint: Разрешаем content и ограничиваем url()

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": "true",
   "main": "index.js",
   "scripts": {
-    "start": "NODE_ENV=development node server.js",
+    "start": "node server.js",
     "test": "eslint . && npm run lint && npm run size-lint && npm run host-lint && npm run build",
     "lint": "npm run stylelint",
     "stylelint": "stylelint hosts/**/*.css",

--- a/server.js
+++ b/server.js
@@ -8,6 +8,10 @@ const path = require('path');
 const qs = require('querystring');
 const compression = require('compression');
 
+if (!process.env.NODE_ENV) {
+    process.env.NODE_ENV = 'development';
+}
+
 const getHostCSS = require('./lib/server/get-host-css');
 
 app.get('/', (req, res) => {

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -18,8 +18,7 @@ module.exports = {
             'mask-border',
             'clip-path'
         ],
-        'declaration-property-value-whitelist': {
-            'content': ['\'\'']
-        }
+        'function-url-scheme-whitelist': '/^\.\//',
+        'function-url-no-scheme-relative': true
     }
 };


### PR DESCRIPTION
* Разрешаем content и ограничиваем url() только относительными путями.
* На Windows не работает переменная окружения перед запуском команды, поэтому переносим её в код.
<span id="turbo-content-start"></span>

****

🚀 — [master](https://master.turboext.net), [pull request](https://pull-27.turboext.net)