### PR TITLE
Stylelint: Увеличиваем допустимую специфичность

### DIFF
--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -6,7 +6,7 @@ module.exports = {
     rules: {
         'plugin/no-low-performance-animation-properties': true,
         'unit-whitelist': ['px', '%', 'rem', 's', 'ms', 'deg', 'vw', 'vh'],
-        'selector-max-specificity': '0,3,0',
+        'selector-max-specificity': '0,4,0',
         'selector-max-type': 0,
         'at-rule-blacklist': ['font-face', 'import'],
         'property-blacklist': [


### PR DESCRIPTION
Увеличиваем допустимую специфичность до используемой в стандартных стилях.
Обнаружили здесь: https://github.com/turboext/css/pull/25#discussion_r188261129
<span id="turbo-content-start"></span>

****

🚀 — [master](https://master.turboext.net), [pull request](https://pull-30.turboext.net)