### PR TITLE
wikipedia.org: сделал иконку Турбо некликабельной

### DIFF
--- a/hosts/wikipedia.org/style.scss
+++ b/hosts/wikipedia.org/style.scss
@@ -238,11 +238,6 @@ a {
     padding-top: 0;
 }
 
-.page .header > .link {
-    position: relative;
-    z-index: 1;
-}
-
 .header_host {
     padding: 12px 0;
 }


### PR DESCRIPTION
Не нашел, где используются эти стили, но из-за них иконка с ракетой тоже становится кликабельной.

-------------------------------------

### Примеры турбо-страниц вашего сайта
- https://yandex.ru/turbo?text=https%3A%2F%2Fru.wikipedia.org%2Fwiki%2F%25D0%2592%25D0%25B0%25D0%25BB

<!---
Таких тестовых страниц может быть несколько. Они будут использоваться для автоматического формирования ссылок на тестовые стенды. Например: https://yandex.ru/turbo?text=https://rozhdestvenskiy.ru/
--->

### Изменения проверены в следующих браузерах
- [x] Android 4+
- [x] iOS 9+
- [ ] IE 11

Мы рекомендуем проверять изменения в перечисленных браузерах. Это не является блокером к принятию изменений, однако, помните, что вы несёте ответственность за итоговый результат.

### Изменения проверены внутри iframe
- [x] Да

Турбо-страницы чаще всего отображаются внутри iframe. Мы рекомендуем проверять изменения стилей внутри iframe, особенно если проводились изменения с сеткой страницы. 