### PR TITLE
Ссылкам в шапке задана ширина, чтобы уменьшить кликабельную область

### DIFF
--- a/hosts/en.wikipedia.org/style.scss
+++ b/hosts/en.wikipedia.org/style.scss
@@ -4,4 +4,5 @@
 .page .header > .link {
     background: transparent url('./wikipedia-wordmark-en.svg') no-repeat 0 50%;
     background-size: 116px 18px;
+    width: 116px;
 }

--- a/hosts/ru.wikipedia.org/style.scss
+++ b/hosts/ru.wikipedia.org/style.scss
@@ -4,4 +4,5 @@
 .page .header > .link {
     background: transparent url('./wikipedia-wordmark-ru.svg') no-repeat 0 50%;
     background-size: 126px 20px;
+    width: 126px;
 }


### PR DESCRIPTION
### Примеры турбо-страниц вашего сайта
- [Ccылка на ru.wikipedia.org](https://yandex.ru/turbo?text=https%3A%2F%2Fru.wikipedia.org%2Fwiki%2F%25D0%259A%25D0%25BE%25D1%2582%25D0%25B8%25D0%25BA%25D0%25B8%2C_%25D0%25B2%25D0%25BF%25D0%25B5%25D1%2580%25D1%2591%25D0%25B4%21)
- [Ccылка на en.wikipedia.org](https://yandex.ru/turbo?text=https%3A%2F%2Fen.wikipedia.org%2Fwiki%2FADP_%28company%29)

<!---
Таких тестовых страниц может быть несколько. Они будут использоваться для автоматического формирования ссылок на тестовые стенды. Например: https://yandex.ru/turbo?text=https://rozhdestvenskiy.ru/
--->

### Изменения проверены в следующих браузерах
- [ ] Android 4+
- [ ] iOS 9+
- [ ] IE 11

Мы рекомендуем проверять изменения в перечисленных браузерах. Это не является блокером к принятию изменений, однако, помните, что вы несёте ответственность за итоговый результат.

### Изменения проверены внутри iframe
- [ ] Да

Турбо-страницы чаще всего отображаются внутри iframe. Мы рекомендуем проверять изменения стилей внутри iframe, особенно если проводились изменения с сеткой страницы. 
